### PR TITLE
fix: fix indent mismatch between prettier and eslint

### DIFF
--- a/firebase/functions/.eslintrc.js
+++ b/firebase/functions/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
         quotes: ["error", "double"],
         "import/no-unresolved": 0,
         "import/extensions": "off",
-        indent: ["error", 2],
+        indent: ["error", 4],
         "no-console": "error",
         "import/prefer-default-export": "off",
     },


### PR DESCRIPTION
### PR Checklist

-   [x] No duplicate code
-   [x] Follows the design system
-   [x] Follows naming conventions
-   [x] Works on both mobile and desktop
-   [x] Looks the same with dark mode
-   [x] Check with logged-in vs. logged-out users
-   [x] Check with subscribed vs. non-subscribed users
