### PR TITLE
feat: add sign in with Google

### DIFF
--- a/app/(routes)/[lang]/(auth)/google-button.tsx
+++ b/app/(routes)/[lang]/(auth)/google-button.tsx
@@ -1,16 +1,28 @@
 import Button from "@/app/_components/button";
 import GoogleIcon from "@/app/_components/icons/google-icon";
+import LoadingSpinner from "@/app/_components/loading-spinner";
 import { ButtonHTMLAttributes } from "react";
 
+type GoogleButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+    isLoading: boolean;
+};
+
 export default function GoogleButton({
+    isLoading,
     children,
     ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: GoogleButtonProps) {
     return (
         <Button type="button" variant="secondary" {...props}>
             <div className="flex flex-row items-center gap-2 justify-center">
-                <GoogleIcon />
-                {children}
+                {isLoading ? (
+                    <LoadingSpinner />
+                ) : (
+                    <>
+                        <GoogleIcon />
+                        {children}
+                    </>
+                )}
             </div>
         </Button>
     );

--- a/app/(routes)/[lang]/(auth)/google-button.tsx
+++ b/app/(routes)/[lang]/(auth)/google-button.tsx
@@ -1,0 +1,17 @@
+import Button from "@/app/_components/button";
+import GoogleIcon from "@/app/_components/icons/google-icon";
+import { ButtonHTMLAttributes } from "react";
+
+export default function GoogleButton({
+    children,
+    ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+    return (
+        <Button type="button" variant="secondary" {...props}>
+            <div className="flex flex-row items-center gap-2 justify-center">
+                <GoogleIcon />
+                {children}
+            </div>
+        </Button>
+    );
+}

--- a/app/(routes)/[lang]/(auth)/sign-in/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-in/form.tsx
@@ -25,8 +25,11 @@ export default function SignInForm({ dict, ...props }: SignInFormProps) {
     const { user, loading: isLoadingUser } = useAuth();
 
     const { signIn, isLoading, errors } = useSignIn();
-    const { signInWithGoogle, error: errorSigningInWithGoogle } =
-        useSignInWithGoogle();
+    const {
+        signInWithGoogle,
+        error: errorSigningInWithGoogle,
+        isLoading: isLoadingGoogleSignIn,
+    } = useSignInWithGoogle();
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -34,7 +37,7 @@ export default function SignInForm({ dict, ...props }: SignInFormProps) {
         signIn(formData);
     };
 
-    if (user) {
+    if (user && !isLoadingGoogleSignIn) {
         router.push(ROUTES.DASHBOARD);
         return null;
     }
@@ -66,7 +69,11 @@ export default function SignInForm({ dict, ...props }: SignInFormProps) {
             <Button type="submit" disabled={isLoading || !!user}>
                 {isLoading ? <LoadingSpinner /> : dict.sign_in}
             </Button>
-            <GoogleButton onClick={signInWithGoogle}>
+            <GoogleButton
+                isLoading={isLoadingGoogleSignIn}
+                onClick={signInWithGoogle}
+                disabled={isLoadingGoogleSignIn || isLoading}
+            >
                 {dict.sign_in_with_google}
             </GoogleButton>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}

--- a/app/(routes)/[lang]/(auth)/sign-in/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-in/form.tsx
@@ -70,7 +70,9 @@ export default function SignInForm({ dict, ...props }: SignInFormProps) {
                 {dict.sign_in_with_google}
             </GoogleButton>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}
-            {errorSigningInWithGoogle && <ErrorP>google error</ErrorP>}
+            {errorSigningInWithGoogle && (
+                <ErrorP>{dict.error_signing_in_with_google}</ErrorP>
+            )}
 
             <p className="text-center text-base font-medium text-slate-700">
                 {dict.do_you_not_have_an_account}{" "}

--- a/app/(routes)/[lang]/(auth)/sign-in/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-in/form.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { FormEvent, FormHTMLAttributes, useId } from "react";
-import Input from "@/app/_components/input";
 import Button from "@/app/_components/button";
-import useSignIn from "@/app/_hooks/use-sign-in";
 import ErrorP from "@/app/_components/error-p";
+import Input from "@/app/_components/input";
 import LoadingSpinner from "@/app/_components/loading-spinner";
+import { ROUTES } from "@/app/_constants/routes";
 import { useAuth } from "@/app/_contexts/auth-context";
 import { Dictionary } from "@/app/_dictionaries/type";
+import useSignIn from "@/app/_hooks/use-sign-in";
+import useSignInWithGoogle from "@/app/_hooks/use-sign-in-with-google";
 import Link from "next/link";
-import { ROUTES } from "@/app/_constants/routes";
 import { useRouter } from "next/navigation";
+import { FormEvent, FormHTMLAttributes, useId } from "react";
+import GoogleButton from "../google-button";
 
 type SignInFormProps = FormHTMLAttributes<HTMLFormElement> & {
     dict: Dictionary;
@@ -23,6 +25,8 @@ export default function SignInForm({ dict, ...props }: SignInFormProps) {
     const { user, loading: isLoadingUser } = useAuth();
 
     const { signIn, isLoading, errors } = useSignIn();
+    const { signInWithGoogle, error: errorSigningInWithGoogle } =
+        useSignInWithGoogle();
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -62,7 +66,11 @@ export default function SignInForm({ dict, ...props }: SignInFormProps) {
             <Button type="submit" disabled={isLoading || !!user}>
                 {isLoading ? <LoadingSpinner /> : dict.sign_in}
             </Button>
+            <GoogleButton onClick={signInWithGoogle}>
+                {dict.sign_in_with_google}
+            </GoogleButton>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}
+            {errorSigningInWithGoogle && <ErrorP>google error</ErrorP>}
 
             <p className="text-center text-base font-medium text-slate-700">
                 {dict.do_you_not_have_an_account}{" "}

--- a/app/(routes)/[lang]/(auth)/sign-up/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-up/form.tsx
@@ -107,7 +107,9 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
                 {dict.sign_up_with_google}
             </GoogleButton>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}
-            {errorSigningInWithGoogle && <ErrorP>google error</ErrorP>}
+            {errorSigningInWithGoogle && (
+                <ErrorP>{dict.error_signing_in_with_google}</ErrorP>
+            )}
 
             <p className="text-center text-base font-medium text-slate-700">
                 {dict.do_you_already_have_an_account}{" "}

--- a/app/(routes)/[lang]/(auth)/sign-up/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-up/form.tsx
@@ -25,8 +25,11 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
 
     const { user, loading: isLoadingUser } = useAuth();
     const { signUp, isLoading, errors } = useSignUp();
-    const { signInWithGoogle, error: errorSigningInWithGoogle } =
-        useSignInWithGoogle();
+    const {
+        signInWithGoogle,
+        error: errorSigningInWithGoogle,
+        isLoading: isLoadingGoogleSignIn,
+    } = useSignInWithGoogle();
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -34,7 +37,7 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
         signUp(formData);
     };
 
-    if (user) {
+    if (user && !isLoadingGoogleSignIn) {
         router.push(ROUTES.DASHBOARD);
         return null;
     }
@@ -103,7 +106,11 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
             <Button type="submit" disabled={isLoading || !!user}>
                 {isLoading ? <LoadingSpinner /> : "Sign Up"}
             </Button>
-            <GoogleButton onClick={signInWithGoogle}>
+            <GoogleButton
+                isLoading={isLoadingGoogleSignIn}
+                onClick={signInWithGoogle}
+                disabled={isLoadingGoogleSignIn || isLoading}
+            >
                 {dict.sign_up_with_google}
             </GoogleButton>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}

--- a/app/(routes)/[lang]/(auth)/sign-up/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-up/form.tsx
@@ -12,8 +12,8 @@ import Link from "next/link";
 import { Dictionary } from "@/app/_dictionaries/type";
 import { ROUTES } from "@/app/_constants/routes";
 import { useRouter } from "next/navigation";
-import GoogleIcon from "@/app/_components/icons/google-icon";
 import useSignInWithGoogle from "@/app/_hooks/use-sign-in-with-google";
+import GoogleButton from "../google-button";
 
 type SignUpFormProps = FormHTMLAttributes<HTMLFormElement> & {
     dict: Dictionary;
@@ -103,16 +103,9 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
             <Button type="submit" disabled={isLoading || !!user}>
                 {isLoading ? <LoadingSpinner /> : "Sign Up"}
             </Button>
-            <Button
-                type="button"
-                variant="secondary"
-                onClick={() => signInWithGoogle()}
-            >
-                <div className="flex flex-row items-center gap-2 justify-center">
-                    <GoogleIcon />
-                    <p>{dict.sign_up_with_google}</p>
-                </div>
-            </Button>
+            <GoogleButton onClick={signInWithGoogle}>
+                {dict.sign_up_with_google}
+            </GoogleButton>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}
             {errorSigningInWithGoogle && <ErrorP>google error</ErrorP>}
 

--- a/app/(routes)/[lang]/(auth)/sign-up/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-up/form.tsx
@@ -13,6 +13,7 @@ import { Dictionary } from "@/app/_dictionaries/type";
 import { ROUTES } from "@/app/_constants/routes";
 import { useRouter } from "next/navigation";
 import GoogleIcon from "@/app/_components/icons/google-icon";
+import useSignInWithGoogle from "@/app/_hooks/use-sign-in-with-google";
 
 type SignUpFormProps = FormHTMLAttributes<HTMLFormElement> & {
     dict: Dictionary;
@@ -24,6 +25,8 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
 
     const { user, loading: isLoadingUser } = useAuth();
     const { signUp, isLoading, errors } = useSignUp();
+    const { signInWithGoogle, error: errorSigningInWithGoogle } =
+        useSignInWithGoogle();
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -100,13 +103,18 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
             <Button type="submit" disabled={isLoading || !!user}>
                 {isLoading ? <LoadingSpinner /> : "Sign Up"}
             </Button>
-            <Button type="button" variant="secondary">
+            <Button
+                type="button"
+                variant="secondary"
+                onClick={() => signInWithGoogle()}
+            >
                 <div className="flex flex-row items-center gap-2 justify-center">
                     <GoogleIcon />
                     <p>{dict.sign_up_with_google}</p>
                 </div>
             </Button>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}
+            {errorSigningInWithGoogle && <ErrorP>google error</ErrorP>}
 
             <p className="text-center text-base font-medium text-slate-700">
                 {dict.do_you_already_have_an_account}{" "}

--- a/app/(routes)/[lang]/(auth)/sign-up/form.tsx
+++ b/app/(routes)/[lang]/(auth)/sign-up/form.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { Dictionary } from "@/app/_dictionaries/type";
 import { ROUTES } from "@/app/_constants/routes";
 import { useRouter } from "next/navigation";
+import GoogleIcon from "@/app/_components/icons/google-icon";
 
 type SignUpFormProps = FormHTMLAttributes<HTMLFormElement> & {
     dict: Dictionary;
@@ -98,6 +99,12 @@ export default function SignUpForm({ dict, ...props }: SignUpFormProps) {
 
             <Button type="submit" disabled={isLoading || !!user}>
                 {isLoading ? <LoadingSpinner /> : "Sign Up"}
+            </Button>
+            <Button type="button" variant="secondary">
+                <div className="flex flex-row items-center gap-2 justify-center">
+                    <GoogleIcon />
+                    <p>{dict.sign_up_with_google}</p>
+                </div>
             </Button>
             {errors?.unknown && <ErrorP>{dict[errors.unknown]}</ErrorP>}
 

--- a/app/_components/icons/google-icon.tsx
+++ b/app/_components/icons/google-icon.tsx
@@ -1,0 +1,42 @@
+/*
+Icon from Bootstrap Icons
+
+The MIT License (MIT)
+
+Copyright (c) 2019-2024 The Bootstrap Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+export default function GoogleIcon({
+    ...props
+}: React.SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            fill="currentColor"
+            viewBox="0 0 16 16"
+            {...props}
+        >
+            <path d="M15.545 6.558a9.4 9.4 0 0 1 .139 1.626c0 2.434-.87 4.492-2.384 5.885h.002C11.978 15.292 10.158 16 8 16A8 8 0 1 1 8 0a7.7 7.7 0 0 1 5.352 2.082l-2.284 2.284A4.35 4.35 0 0 0 8 3.166c-2.087 0-3.86 1.408-4.492 3.304a4.8 4.8 0 0 0 0 3.063h.003c.635 1.893 2.405 3.301 4.492 3.301 1.078 0 2.004-.276 2.722-.764h-.003a3.7 3.7 0 0 0 1.599-2.431H8v-3.08z" />
+        </svg>
+    );
+}

--- a/app/_dictionaries/en-us.ts
+++ b/app/_dictionaries/en-us.ts
@@ -22,6 +22,7 @@ export const enUS: Dictionary = {
     do_you_not_have_an_account: "Do you not have an account?",
     sign_up_with_google: "Sign Up With Google",
     sign_in_with_google: "Sign In With Google",
+    error_signing_in_with_google: "Error signing in with Google",
 
     // profile
     save: "Save",

--- a/app/_dictionaries/en-us.ts
+++ b/app/_dictionaries/en-us.ts
@@ -20,6 +20,8 @@ export const enUS: Dictionary = {
     privacy_policy: "privacy policy",
     do_you_already_have_an_account: "Do you already have an account?",
     do_you_not_have_an_account: "Do you not have an account?",
+    sign_up_with_google: "Sign Up With Google",
+    sign_in_with_google: "Sign In With Google",
 
     // profile
     save: "Save",

--- a/app/_dictionaries/nb-no.ts
+++ b/app/_dictionaries/nb-no.ts
@@ -22,6 +22,7 @@ export const nbNO: Dictionary = {
     do_you_not_have_an_account: "Har du ikke en konto?",
     sign_in_with_google: "Logg inn med Google",
     sign_up_with_google: "Registrer deg med Google",
+    error_signing_in_with_google: "Feil ved Google-innlogging",
 
     // profile
     save: "Lagre",

--- a/app/_dictionaries/nb-no.ts
+++ b/app/_dictionaries/nb-no.ts
@@ -20,6 +20,8 @@ export const nbNO: Dictionary = {
     privacy_policy: "personvernerklæringen",
     do_you_already_have_an_account: "Har du allerede en konto?",
     do_you_not_have_an_account: "Har du ikke en konto?",
+    sign_in_with_google: "Logg inn med Google",
+    sign_up_with_google: "Registrer deg med Google",
 
     // profile
     save: "Lagre",

--- a/app/_dictionaries/type.ts
+++ b/app/_dictionaries/type.ts
@@ -17,6 +17,8 @@ export type Dictionary = {
     privacy_policy: string;
     do_you_already_have_an_account: string;
     do_you_not_have_an_account: string;
+    sign_up_with_google: string;
+    sign_in_with_google: string;
 
     // profile
     save: string;

--- a/app/_dictionaries/type.ts
+++ b/app/_dictionaries/type.ts
@@ -19,6 +19,7 @@ export type Dictionary = {
     do_you_not_have_an_account: string;
     sign_up_with_google: string;
     sign_in_with_google: string;
+    error_signing_in_with_google: string;
 
     // profile
     save: string;

--- a/app/_hooks/use-sign-in-with-google.tsx
+++ b/app/_hooks/use-sign-in-with-google.tsx
@@ -7,8 +7,11 @@ import getUser from "@/firebase/firestore/get-user";
 
 export default function useSignInWithGoogle() {
     const [error, setError] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
 
     async function signInWithGoogle() {
+        setIsLoading(true);
+
         try {
             const {
                 user: { email, uid },
@@ -27,7 +30,9 @@ export default function useSignInWithGoogle() {
         } catch {
             setError(true);
         }
+
+        setIsLoading(false);
     }
 
-    return { signInWithGoogle, error };
+    return { signInWithGoogle, error, isLoading };
 }

--- a/app/_hooks/use-sign-in-with-google.tsx
+++ b/app/_hooks/use-sign-in-with-google.tsx
@@ -1,0 +1,30 @@
+import { googleProvider } from "@/firebase/auth/providers";
+import { auth, functions } from "@/firebase/client";
+import { signInWithPopup } from "firebase/auth";
+import { httpsCallable } from "firebase/functions";
+import { useState } from "react";
+
+export default function useSignInWithGoogle() {
+    const [error, setError] = useState(false);
+
+    async function signInWithGoogle() {
+        try {
+            const {
+                user: { email },
+            } = await signInWithPopup(auth, googleProvider);
+
+            const createUserOnServer = httpsCallable(functions, "createUser");
+            const username = email!.split("@")[0].replace(".", "_");
+
+            try {
+                await createUserOnServer({ username });
+            } catch {
+                // User exists, don't create
+            }
+        } catch {
+            setError(true);
+        }
+    }
+
+    return { signInWithGoogle, error };
+}

--- a/firebase/auth/providers.ts
+++ b/firebase/auth/providers.ts
@@ -1,0 +1,3 @@
+import { GoogleAuthProvider } from "firebase/auth";
+
+export const googleProvider = new GoogleAuthProvider();

--- a/firebase/firestore/get-user.ts
+++ b/firebase/firestore/get-user.ts
@@ -4,6 +4,11 @@ import { userSchema } from "../../app/_entities/models/user";
 
 export default async function getUser(uid: string) {
     const userDoc = await getDoc(doc(db, "users", uid));
+
+    if (!userDoc.exists()) {
+        return null;
+    }
+
     const id = userDoc.id;
     const data = userDoc.data();
     return userSchema.parse({ id, ...data });


### PR DESCRIPTION
Add sign in/up with Google button. For the time being, handle sign in and sign up the same.

### PR Checklist

-   [x] No duplicate code
-   [x] Follows the design system
-   [x] Follows naming conventions
-   [x] Works on both mobile and desktop
-   [x] Looks the same with dark mode
-   [x] Has both English and Norwegian translations
-   [x] Check with logged-in vs. logged-out users
-   [x] Check with subscribed vs. non-subscribed users
-   [x] Includes license and attribution for any third-party assets
